### PR TITLE
Refactor: Modernize Python packaging to use pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,26 @@
+[build-system]
+requires = ["setuptools>=42", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "urmom"
+version = "0.1.1"
+authors = [
+  { name="Daniel Merja", email="danielmerja@gmail.com" },
+]
+description = "A Python package that prints 'URMOM' in ASCII art."
+readme = "README.md"
+requires-python = ">=3.6"
+classifiers = [
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+]
+keywords = ["ascii", "art", "funny", "urmom"]
+
+[project.urls]
+"Homepage" = "https://github.com/danielmerja/urmom"
+"Bug Tracker" = "https://github.com/danielmerja/urmom/issues"
+
+[project.scripts]
+urmom = "urmom.ascii_art:print_urmom"

--- a/setup.py
+++ b/setup.py
@@ -1,24 +1,4 @@
-from setuptools import setup, find_packages
+from setuptools import setup
 
-setup(
-    name="urmom",
-    version="0.1.1",
-    author="Daniel Merja",
-    author_email="danielmerja@gmail.com",
-    description="A Python package that prints 'URMOM' in ASCII art.",
-    long_description=open("README.md").read(),
-    long_description_content_type="text/markdown",
-    url="https://github.com/danielmerja/urmom",
-    packages=find_packages(),
-    classifiers=[
-        "Programming Language :: Python :: 3",
-        "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent",
-    ],
-    python_requires='>=3.6',
-    entry_points={
-        'console_scripts': [
-            'urmom=urmom.ascii_art:print_urmom',
-        ],
-    },
-)
+if __name__ == "__main__":
+    setup()


### PR DESCRIPTION
This commit updates the project's packaging configuration to align with modern Python standards (PEP 517, PEP 518, PEP 621).

Key changes:
- Introduced `pyproject.toml` to define build system requirements and project metadata.
- Simplified `setup.py` to a minimal version, as most configurations have been migrated to `pyproject.toml`.
- Verified that the package builds successfully with the new configuration, producing both source and wheel distributions.

The `.gitignore` and `README.md` files were reviewed and required no changes.